### PR TITLE
Use ShipmentInterface in ShippingExport's ORM mapping

### DIFF
--- a/src/Resources/config/doctrine/ShippingExport.orm.yml
+++ b/src/Resources/config/doctrine/ShippingExport.orm.yml
@@ -23,7 +23,7 @@ BitBag\SyliusShippingExportPlugin\Entity\ShippingExport:
             nullable: true
     oneToOne:
         shipment:
-            targetEntity: Sylius\Component\Core\Model\Shipment
+            targetEntity: Sylius\Component\Shipping\Model\ShipmentInterface
             joinColumn:
                 name: shipment_id
                 referencedColumnName: id


### PR DESCRIPTION
Without the interface Shipment entity does not resolve correctly in case it's overridden.