### PR TITLE
Add pending state

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,13 @@
         "vimeo/psalm": "4.7.1"
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "symfony/thanks": true,
+            "composer/package-versions-deprecated": true,
+            "dealerdirect/phpcodesniffer-composer-installer": true,
+            "phpstan/extension-installer": true
+        }
     },
     "autoload": {
         "psr-4": {

--- a/features/exporting_shipping_data_to_api.feature
+++ b/features/exporting_shipping_data_to_api.feature
@@ -43,6 +43,14 @@ Feature: Managing shipping gateway
         Then I should be notified that there are no new shipments to export
 
     @ui
+    Scenario: Exporting all new and pending shipments
+        Given there are 2 exports marked as pending
+        When I go to the shipping export page
+        And I export all new shipments
+        Then I should be notified that the shipment has been exported
+        And all 5 shipments should have "Exported" state
+
+    @ui
     Scenario: Throwing an external API error while exporting shipments
         Given the external shipping API is down
         When I go to the shipping export page

--- a/src/Controller/ShippingExportController.php
+++ b/src/Controller/ShippingExportController.php
@@ -13,6 +13,7 @@ namespace BitBag\SyliusShippingExportPlugin\Controller;
 use BitBag\SyliusShippingExportPlugin\Event\ExportShipmentEvent;
 use BitBag\SyliusShippingExportPlugin\Repository\ShippingExportRepositoryInterface;
 use Sylius\Bundle\ResourceBundle\Controller\ResourceController;
+use Sylius\Component\Resource\Model\ResourceInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Webmozart\Assert\Assert;
@@ -26,7 +27,7 @@ final class ShippingExportController extends ResourceController
     {
         $configuration = $this->requestConfigurationFactory->create($this->metadata, $request);
 
-        $shippingExports = $this->repository->findAllWithNewState();
+        $shippingExports = $this->repository->findAllWithNewOrPendingState();
 
         if (0 === count($shippingExports)) {
             $this->addFlash('error', 'bitbag.ui.no_new_shipments_to_export');
@@ -49,6 +50,7 @@ final class ShippingExportController extends ResourceController
     {
         $configuration = $this->requestConfigurationFactory->create($this->metadata, $request);
 
+        /** @var ResourceInterface|null $shippingExport */
         $shippingExport = $this->repository->find($request->get('id'));
         Assert::notNull($shippingExport);
 

--- a/src/Entity/ShippingExportInterface.php
+++ b/src/Entity/ShippingExportInterface.php
@@ -17,6 +17,8 @@ interface ShippingExportInterface extends ResourceInterface
 {
     public const STATE_NEW = 'new';
 
+    public const STATE_PENDING = 'pending';
+
     public const STATE_EXPORTED = 'exported';
 
     public function getShipment(): ?ShipmentInterface;

--- a/src/Repository/ShippingExportRepository.php
+++ b/src/Repository/ShippingExportRepository.php
@@ -27,6 +27,21 @@ class ShippingExportRepository extends EntityRepository implements ShippingExpor
         ;
     }
 
+    /**
+     * @inheritdoc
+     */
+    public function findAllWithNewState(): array
+    {
+        trigger_deprecation('bitbag/shipping-export-plugin', '1.6', 'The "%s()" method is deprecated, use "ShippingExportRepository::findAllWithNewOrPendingState" instead.', __METHOD__);
+
+        return $this->createQueryBuilder('o')
+            ->where('o.state = :newState')
+            ->setParameter(self::NEW_STATE_PARAMETER, ShippingExportInterface::STATE_NEW)
+            ->getQuery()
+            ->getResult()
+        ;
+    }
+
     public function findAllWithNewOrPendingState(): array
     {
         return $this->createQueryBuilder('o')

--- a/src/Repository/ShippingExportRepository.php
+++ b/src/Repository/ShippingExportRepository.php
@@ -16,6 +16,10 @@ use Sylius\Bundle\ResourceBundle\Doctrine\ORM\EntityRepository;
 
 class ShippingExportRepository extends EntityRepository implements ShippingExportRepositoryInterface
 {
+    public const NEW_STATE_PARAMETER = 'newState';
+
+    public const PENDING_STATE_PARAMETER = 'pendingState';
+
     public function createListQueryBuilder(): QueryBuilder
     {
         return $this->createQueryBuilder('o')
@@ -23,11 +27,12 @@ class ShippingExportRepository extends EntityRepository implements ShippingExpor
         ;
     }
 
-    public function findAllWithNewState(): array
+    public function findAllWithNewOrPendingState(): array
     {
         return $this->createQueryBuilder('o')
-            ->where('o.state = :newState')
-            ->setParameter('newState', ShippingExportInterface::STATE_NEW)
+            ->where('o.state = :newState OR o.state = :pendingState')
+            ->setParameter(self::NEW_STATE_PARAMETER, ShippingExportInterface::STATE_NEW)
+            ->setParameter(self::PENDING_STATE_PARAMETER, ShippingExportInterface::STATE_PENDING)
             ->getQuery()
             ->getResult()
         ;

--- a/src/Repository/ShippingExportRepositoryInterface.php
+++ b/src/Repository/ShippingExportRepositoryInterface.php
@@ -17,5 +17,10 @@ interface ShippingExportRepositoryInterface extends RepositoryInterface
 {
     public function createListQueryBuilder(): QueryBuilder;
 
+    /**
+     * @depracated since SyliusShippingExportPlugin 1.6, use ShippingExportRepository::findAllWithNewOrPendingState instead.
+     */
+    public function findAllWithNewState(): array;
+
     public function findAllWithNewOrPendingState(): array;
 }

--- a/src/Repository/ShippingExportRepositoryInterface.php
+++ b/src/Repository/ShippingExportRepositoryInterface.php
@@ -17,5 +17,5 @@ interface ShippingExportRepositoryInterface extends RepositoryInterface
 {
     public function createListQueryBuilder(): QueryBuilder;
 
-    public function findAllWithNewState(): array;
+    public function findAllWithNewOrPendingState(): array;
 }

--- a/src/Resources/translations/messages.en.yml
+++ b/src/Resources/translations/messages.en.yml
@@ -10,6 +10,7 @@ bitbag:
         manage_shipping_exports: Manage shipping export
         manage_shipping_gateways: Manage shipping gateways
         new: New
+        pending: Pending
         no_shipping_label: No label
         not_exported_yet: Not exported yet
         shipping_export_label: Shipping label

--- a/src/Resources/translations/messages.pl.yml
+++ b/src/Resources/translations/messages.pl.yml
@@ -10,6 +10,7 @@ bitbag:
         manage_shipping_exports: Zarządzaj eksportem przesyłek
         manage_shipping_gateways: Zarządzaj bramami dostawców
         new: Nowy
+        pending: Oczekujący
         no_shipping_label: Brak etykiety
         not_exported_yet: Nie eksportowano
         shipping_export_label: Etykieta przesyłki

--- a/src/Resources/views/ShippingExport/Grid/Field/state.html.twig
+++ b/src/Resources/views/ShippingExport/Grid/Field/state.html.twig
@@ -1,6 +1,6 @@
 {% set value = 'bitbag.ui.' ~ data.state %}
 
-{% if  data.state == 'new' %}
+{% if  data.state == 'new' or data.state == 'pending' %}
     {% include '@BitBagSyliusShippingExportPlugin/ShippingExport/Partial/_exportShipment.html.twig' %}
 {% else %}
     <span class="shipping-export-state ui green label"><i class="check icon"></i> {{ value|trans }}</span>

--- a/src/Resources/views/ShippingExport/Partial/_exportShipment.html.twig
+++ b/src/Resources/views/ShippingExport/Partial/_exportShipment.html.twig
@@ -1,4 +1,7 @@
 <form action="{{ path('bitbag_admin_export_single_shipment', {'id' : data.id}) }}" method="POST">
     <input type="hidden" name="_method" value="PUT">
-    <button class="ui labeled icon primary button mini shipping-export-state"><i class="arrow up icon"></i> {{ value|trans }}</button>
+    <button class="ui labeled icon {% if data.state == 'new' %} primary {% endif %} {% if data.state == 'pending' %} yellow {% endif %} button mini shipping-export-state">
+        <i class="{% if data.state == 'new' %} arrow up {% endif %} {% if data.state == 'pending' %} clock outline {% endif %} icon"></i>
+        {{ value|trans }}
+    </button>
 </form>

--- a/tests/Behat/Context/Setup/ShippingExportContext.php
+++ b/tests/Behat/Context/Setup/ShippingExportContext.php
@@ -12,6 +12,7 @@ namespace Tests\BitBag\SyliusShippingExportPlugin\Behat\Context\Setup;
 
 use Behat\Behat\Context\Context;
 use BitBag\SyliusShippingExportPlugin\Entity\ShippingExport;
+use BitBag\SyliusShippingExportPlugin\Entity\ShippingExportInterface;
 use BitBag\SyliusShippingExportPlugin\Entity\ShippingGatewayInterface;
 use BitBag\SyliusShippingExportPlugin\Repository\ShippingExportRepositoryInterface;
 use BitBag\SyliusShippingExportPlugin\Repository\ShippingGatewayRepositoryInterface;
@@ -127,5 +128,19 @@ final class ShippingExportContext implements Context
         $shippingExport->setShippingGateway($shippingGateway);
 
         $this->shippingExportRepository->add($shippingExport);
+    }
+
+    /**
+     * @Given there are :numberOfExports exports marked as pending
+     */
+    public function thereAreExportsMarkedAsPending(int $numberOfExports): void
+    {
+        /** @var ShippingExportInterface[] $exports */
+        $exports = $this->shippingExportRepository->findBy([], null, $numberOfExports);
+
+        foreach ($exports as $export) {
+            $export->setState(ShippingExportInterface::STATE_PENDING);
+            $this->shippingExportRepository->add($export);
+        }
     }
 }

--- a/tests/Behat/Context/Ui/Admin/ShippingExportContext.php
+++ b/tests/Behat/Context/Ui/Admin/ShippingExportContext.php
@@ -47,7 +47,7 @@ final class ShippingExportContext implements Context
      */
     public function iShouldSeeNewShipmentsToExportWithState(string $number, string $state): void
     {
-        Assert::eq((int) $number, count($this->indexPage->getShipmentsWithState($state)));
+        Assert::eq(count($this->indexPage->getShipmentsWithState($state)), (int) $number);
     }
 
     /**


### PR DESCRIPTION
While working with InPost plugin I've noticed the API provider doesn't always return the correct response on time. In case of InPost to generate a shipping label it must have `confirmed` status but sometimes it returns `created` first and on the second call it returns `confirmed` with a shipping label.

To handle this situation in this PR I've created a `pending` state. If we get an internal API provider's ID of shipping label we can save it and mark export as pending. On a next export it'll use this ID to check if shipping label is ready. Implementation of handling `pending` state depends on the plugin.

To bump only minor version I've introduced `findAllWithNewOrPendingState` method and deprecated `findAllWithNewState` method because it's a part of public API.