### PR TITLE
Support Sylius 1.12

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "require": {
         "php": "^7.3 || ^8.0",
         "bitbag/coding-standard": "^1.0.1",
-        "sylius/sylius": "~1.8.0 || ~1.9.0 || ~1.10.0 || ~1.11.0"
+        "sylius/sylius": "~1.8.0 || ~1.9.0 || ~1.10.0 || ~1.11.0 || ~1.12.0"
     },
     "require-dev": {
         "behat/behat": "^3.6.1",
@@ -30,11 +30,11 @@
         "phpunit/phpunit": "^9.5",
         "sensiolabs/security-checker": "^6.0",
         "sylius-labs/coding-standard": "^4.0",
-        "symfony/browser-kit": "^4.4 || ^5.2",
-        "symfony/debug-bundle": "^4.4 || ^5.2",
-        "symfony/dotenv": "^4.4 || ^5.2",
-        "symfony/intl": "^4.4 || ^5.2",
-        "symfony/web-profiler-bundle": "^4.4 || ^5.2",
+        "symfony/browser-kit": "^4.4 || ^5.2 || ^6.0",
+        "symfony/debug-bundle": "^4.4 || ^5.2 || ^6.0",
+        "symfony/dotenv": "^4.4 || ^5.2 || ^6.0",
+        "symfony/intl": "^4.4 || ^5.2 || ^6.0",
+        "symfony/web-profiler-bundle": "^4.4 || ^5.2 || ^6.0",
         "vimeo/psalm": "4.7.1",
         "polishsymfonycommunity/symfony-mocker-container": "^1.0",
         "friendsofsymfony/oauth-server-bundle": "^1.6 || >2.0.0-alpha.0 ^2.0@dev"

--- a/composer.json
+++ b/composer.json
@@ -5,12 +5,12 @@
     "license": "MIT",
     "require": {
         "php": "^7.3 || ^8.0",
-        "bitbag/coding-standard": "^1.0.1 || ^2.0.1",
         "sylius/sylius": "~1.8.0 || ~1.9.0 || ~1.10.0 || ~1.11.0 || ~1.12.0"
     },
     "require-dev": {
         "behat/behat": "^3.6.1",
         "behat/mink-selenium2-driver": "^1.4",
+        "bitbag/coding-standard": "^1.0.1 || ^2.0.1",
         "dmore/behat-chrome-extension": "^1.3",
         "dmore/chrome-mink-driver": "^2.7",
         "friends-of-behat/mink": "^1.8",

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "license": "MIT",
     "require": {
         "php": "^7.3 || ^8.0",
-        "bitbag/coding-standard": "^1.0.1",
+        "bitbag/coding-standard": "^1.0.1 || ^2.0.1",
         "sylius/sylius": "~1.8.0 || ~1.9.0 || ~1.10.0 || ~1.11.0 || ~1.12.0"
     },
     "require-dev": {
@@ -23,10 +23,10 @@
         "friends-of-behat/variadic-extension": "^1.3",
         "phpspec/phpspec": "^7.0",
         "phpstan/extension-installer": "^1.0",
-        "phpstan/phpstan": "0.12.85",
+        "phpstan/phpstan": "0.12.85 || ^1.4",
         "phpstan/phpstan-doctrine": "0.12.33",
-        "phpstan/phpstan-strict-rules": "^0.12.0",
-        "phpstan/phpstan-webmozart-assert": "0.12.12",
+        "phpstan/phpstan-strict-rules": "^0.12.0 || ^1.0",
+        "phpstan/phpstan-webmozart-assert": "0.12.12 || ^1.0",
         "phpunit/phpunit": "^9.5",
         "sensiolabs/security-checker": "^6.0",
         "sylius-labs/coding-standard": "^4.0",

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "description": "Shipping data export environment for Sylius platform applications",
     "license": "MIT",
     "require": {
-        "php": "^7.3 || ^8.0",
+        "php": "^7.4 || ^8.0",
         "sylius/sylius": "~1.8.0 || ~1.9.0 || ~1.10.0 || ~1.11.0 || ~1.12.0"
     },
     "require-dev": {

--- a/src/Controller/ShippingExportController.php
+++ b/src/Controller/ShippingExportController.php
@@ -11,7 +11,6 @@ declare(strict_types=1);
 namespace BitBag\SyliusShippingExportPlugin\Controller;
 
 use BitBag\SyliusShippingExportPlugin\Event\ExportShipmentEvent;
-use BitBag\SyliusShippingExportPlugin\Repository\ShippingExportRepositoryInterface;
 use Sylius\Bundle\ResourceBundle\Controller\ResourceController;
 use Sylius\Component\Resource\Repository\RepositoryInterface;
 use Sylius\Component\Resource\Model\ResourceInterface;
@@ -21,7 +20,6 @@ use Webmozart\Assert\Assert;
 
 final class ShippingExportController extends ResourceController
 {
-    /** @var ShippingExportRepositoryInterface */
     protected RepositoryInterface $repository;
 
     public function exportAllNewShipmentsAction(Request $request): RedirectResponse

--- a/src/Controller/ShippingExportController.php
+++ b/src/Controller/ShippingExportController.php
@@ -13,6 +13,7 @@ namespace BitBag\SyliusShippingExportPlugin\Controller;
 use BitBag\SyliusShippingExportPlugin\Event\ExportShipmentEvent;
 use BitBag\SyliusShippingExportPlugin\Repository\ShippingExportRepositoryInterface;
 use Sylius\Bundle\ResourceBundle\Controller\ResourceController;
+use Sylius\Component\Resource\Repository\RepositoryInterface;
 use Sylius\Component\Resource\Model\ResourceInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -21,7 +22,7 @@ use Webmozart\Assert\Assert;
 final class ShippingExportController extends ResourceController
 {
     /** @var ShippingExportRepositoryInterface */
-    protected $repository;
+    protected RepositoryInterface $repository;
 
     public function exportAllNewShipmentsAction(Request $request): RedirectResponse
     {

--- a/src/Controller/ShippingExportDownloadLabelAction.php
+++ b/src/Controller/ShippingExportDownloadLabelAction.php
@@ -21,14 +21,11 @@ use Webmozart\Assert\Assert;
 
 final class ShippingExportDownloadLabelAction
 {
-    /** @var Filesystem */
-    private $filesystem;
+    private Filesystem $filesystem;
 
-    /** @var ShippingExportRepositoryInterface */
-    private $repository;
+    private ShippingExportRepositoryInterface $repository;
 
-    /** @var string */
-    private $shippingLabelsPath;
+    private string $shippingLabelsPath;
 
     public function __construct(
         Filesystem $filesystem,

--- a/src/Event/ExportShipmentEvent.php
+++ b/src/Event/ExportShipmentEvent.php
@@ -28,23 +28,17 @@ class ExportShipmentEvent extends Event
 
     public const SHORT_NAME = 'export_shipment';
 
-    /** @var ShippingExportInterface */
-    private $shippingExport;
+    private ShippingExportInterface $shippingExport;
 
-    /** @var FlashBagInterface */
-    private $flashBag;
+    private FlashBagInterface $flashBag;
 
-    /** @var EntityManagerInterface|EntityManager */
-    private $shippingExportManager;
+    private EntityManagerInterface $shippingExportManager;
 
-    /** @var Filesystem */
-    private $filesystem;
+    private Filesystem $filesystem;
 
-    /** @var TranslatorInterface */
-    private $translator;
+    private TranslatorInterface $translator;
 
-    /** @var string */
-    private $shippingLabelsPath;
+    private string $shippingLabelsPath;
 
     public function __construct(
         ShippingExportInterface $shippingExport,

--- a/src/EventListener/PlacingShipmentForGatewayEventListener.php
+++ b/src/EventListener/PlacingShipmentForGatewayEventListener.php
@@ -22,14 +22,11 @@ use Webmozart\Assert\Assert;
 
 final class PlacingShipmentForGatewayEventListener
 {
-    /** @var ShippingGatewayRepositoryInterface */
-    private $shippingGatewayRepository;
+    private ShippingGatewayRepositoryInterface $shippingGatewayRepository;
 
-    /** @var ShippingExportRepositoryInterface */
-    private $shippingExportRepository;
+    private ShippingExportRepositoryInterface $shippingExportRepository;
 
-    /** @var FactoryInterface */
-    private $shippingExportFactory;
+    private FactoryInterface $shippingExportFactory;
 
     public function __construct(
         ShippingGatewayRepositoryInterface $shippingGatewayRepository,

--- a/src/Form/Type/ShippingGatewayType.php
+++ b/src/Form/Type/ShippingGatewayType.php
@@ -22,11 +22,9 @@ use Webmozart\Assert\Assert;
 
 final class ShippingGatewayType extends AbstractResourceType
 {
-    /** @var ShippingGatewayContextInterface */
-    private $shippingGatewayTypeContext;
+    private ShippingGatewayContextInterface $shippingGatewayTypeContext;
 
-    /** @var string */
-    private $shippingMethodModelClass;
+    private string $shippingMethodModelClass;
 
     public function __construct(
         $dataClass,

--- a/src/Resources/config/grids/bitbag_shipping_export.yml
+++ b/src/Resources/config/grids/bitbag_shipping_export.yml
@@ -38,7 +38,7 @@ sylius_grid:
                     type: twig
                     label: sylius.ui.shipping_method
                     path: .
-                    sortable: ~
+                    sortable: shipment.method
                     options:
                         template: "@BitBagSyliusShippingExportPlugin/ShippingExport/Grid/Field/shippingMethod.html.twig"
                 labelPath:

--- a/src/Resources/config/routing/bitbag_shipping_export.yml
+++ b/src/Resources/config/routing/bitbag_shipping_export.yml
@@ -22,13 +22,13 @@ bitbag_admin_export_all_new_shipments:
     path: /shipping-exports/export/all
     methods: [POST, PUT]
     defaults:
-        _controller: bitbag.controller.shipping_export:exportAllNewShipmentsAction
+        _controller: bitbag.controller.shipping_export::exportAllNewShipmentsAction
 
 bitbag_admin_export_single_shipment:
     path: /shipping-exports/export/{id}
     methods: [POST, PUT]
     defaults:
-        _controller: bitbag.controller.shipping_export:exportSingleShipmentAction
+        _controller: bitbag.controller.shipping_export::exportSingleShipmentAction
 
 bitbag_admin_get_shipping_label:
     path: /shipping-exports/label/{id}

--- a/src/Resources/config/routing/bitbag_shipping_gateway.yml
+++ b/src/Resources/config/routing/bitbag_shipping_gateway.yml
@@ -22,7 +22,7 @@ bitbag_admin_shipping_gateway_create:
     path: /shipping-gateways/new/{code}
     methods: [GET, POST]
     defaults:
-        _controller: bitbag.controller.shipping_gateway:createAction
+        _controller: bitbag.controller.shipping_gateway::createAction
         _sylius:
             section: admin
             template: '@SyliusAdmin/Crud/create.html.twig'


### PR DESCRIPTION
- Support Sylius 1.12
- Bugifx for: https://github.com/BitBagCommerce/SyliusShippingExportPlugin/issues/32
- Move coding standard as dev-dependency, because not related with logic itself
- As ShippingExportController extends `ResourceController` from Sylius and new Sylius have typed properties, so refactored to typed properties and PHP 7.4 is minimum version 